### PR TITLE
[4.x] Fix Google Structured Data Errors in Breadcrumbs

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -47,16 +47,23 @@ use Joomla\CMS\Router\Route;
 		// Generate the trail
 		foreach ($list as $key => $item) :
 			if ($key !== $last_item_key) :
-				if (!empty($item->link)) :
-					$breadcrumbItem = '<a itemprop="item" href="' . Route::_($item->link) . '" class="pathway"><span itemprop="name">' . html_entity_decode($item->name, ENT_QUOTES, 'UTF-8') . '</span></a>';
-				else :
-					$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
-				endif;
-				// Render all but last item - along with separator ?>
-				<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="mod-breadcrumbs__item breadcrumb-item"><?php echo $breadcrumbItem; ?>
-					<meta itemprop="position" content="<?php echo $key + 1; ?>">
-				</li>
-			<?php elseif ($show_last) :
+				// Render links with structured data
+				if (!empty($item->link)) : 
+					$breadcrumbItem = '<a itemprop="item" href="' . Route::_($item->link) . '" class="pathway"><span itemprop="name">' . html_entity_decode($item->name, ENT_QUOTES, 'UTF-8') . '</span></a>'; ?>
+					<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="mod-breadcrumbs__item breadcrumb-item">
+						<?php echo $breadcrumbItem; ?>
+						<meta itemprop="position" content="<?php echo $key + 1; ?>">
+					</li>
+
+				<?php 
+				// Render items without links without structured data so Google doesn't flag it as invalid breadcrumbs.
+				else : 
+					$breadcrumbItem = '<span>' . $item->name . '</span>'; ?>
+					<li class="mod-breadcrumbs__item breadcrumb-item">
+						<?php echo $breadcrumbItem; ?>
+					</li>
+				<?php endif;
+			elseif ($show_last) :
 				$breadcrumbItem = '<span itemprop="name">' . html_entity_decode($item->name, ENT_QUOTES, 'UTF-8') . '</span>';
 				// Render last item if required. ?>
 				<li aria-current="page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="mod-breadcrumbs__item breadcrumb-item active"><?php echo $breadcrumbItem; ?>


### PR DESCRIPTION
### Summary of Changes
This PR fixes structured data errors that made Google flag breadcrumbs as invalid.

When a breadcrumb item was a menu heading, instead of a link, Google would flag it as an invalid breadcrumb because it did not have a link. This is fixed by removing the structured data markup from items without a link.

### Testing Instructions
Create a site menu with a menu heading and subpages, like so:
- Home
- Menu Heading
  - Subpage 1

Create a breadcrumbs module. Ensure the module is published and visible on Subpage 1.

Navigate to subpage 1. 
#### If this site is accessible over the internet:
Copy the URL and paste it into the field here: https://search.google.com/test/rich-results

#### If this site is hosted locally:
View source of Subpage 1 and copy it into the code box on https://search.google.com/test/rich-results
(Alternatively, you can find the generated code for the ul and just copy that into the code box.)


### Actual result BEFORE applying this Pull Request
Google detects the breadcrumbs but shows an error: 
<img width="938" alt="Screenshot showing Google Rich Search results error details" src="https://user-images.githubusercontent.com/9141288/149291146-e064c248-eb26-4816-8ce9-1d3c78145bfb.png">

When you click on it to see more, this is the problem:
<img width="938" alt="Screenshot showing Google Rich Search results error details" src="https://user-images.githubusercontent.com/9141288/149291174-9e4ea5a4-c076-4967-8f68-e389d9178699.png">

Google does not consider a breadcrumb item as valid unless it has a link. Since menu headings don't have links, we have to remove the structured data from that item.

### Expected result AFTER applying this Pull Request
Google detects the breadcrumbs and marks them as valid:
<img width="938" alt="Screenshot showing Google Rich Search results with valid notification" src="https://user-images.githubusercontent.com/9141288/149291501-a6c4764b-fc10-4b1a-b2f6-31d32e77523c.png">


### Documentation Changes Required
None as far as I'm aware.